### PR TITLE
Export AuthenticatingActivity

### DIFF
--- a/android/Kegtab/AndroidManifest.xml
+++ b/android/Kegtab/AndroidManifest.xml
@@ -210,6 +210,7 @@
             android:name=".AuthenticatingActivity"
             android:label="@string/app_name"
             android:launchMode="singleTop"
+            android:exported="true"
             android:theme="@android:style/Theme.Holo.Dialog.NoActionBar" />
 
         <!-- ################### -->


### PR DESCRIPTION
When trying to authenticate with an NFC tag, I was getting this error: `W/ActivityManager(  544): Permission Denial: starting Intent { act=android.nfc.action.TECH_DISCOVERED flg=0x30000000 cmp=org.kegbot.app/.AuthenticatingActivity (has extras) } from null (pid=-1, uid=10076) not exported from uid 10077`
