### PR TITLE
Accept pin code on keyboard return

### DIFF
--- a/kegtab/src/main/java/org/kegbot/app/PinActivity.java
+++ b/kegtab/src/main/java/org/kegbot/app/PinActivity.java
@@ -95,7 +95,8 @@ public class PinActivity extends Activity {
     mPinText.setOnEditorActionListener(new OnEditorActionListener() {
       @Override
       public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-        if (actionId == EditorInfo.IME_NULL && event.getAction() == KeyEvent.ACTION_DOWN) {
+        if (isNexusDone(actionId)
+                || (actionId == EditorInfo.IME_NULL && event.getAction() == KeyEvent.ACTION_DOWN)) {
           verifyPin();
           return true;
         }
@@ -117,6 +118,11 @@ public class PinActivity extends Activity {
     if (bar != null) {
       bar.setTitle("");
     }
+  }
+
+  //Events may vary by keyboard; This one works on N7
+  private static boolean isNexusDone(int actionId){
+    return actionId == EditorInfo.IME_ACTION_DONE;
   }
 
   private void onPinSuccess() {


### PR DESCRIPTION
I left 
```java
(actionId == EditorInfo.IME_NULL && event.getAction() == KeyEvent.ACTION_DOWN)
```
figuring it works for some other devices. ``actionId == EditorInfo.IME_ACTION_DONE`` worked for me on the emulator and on a Samsung tablet.