### PR TITLE
Add functionality & configuration option for Turn Screen On During Pour.

### DIFF
--- a/kegtab/src/main/java/org/kegbot/app/PourInProgressActivity.java
+++ b/kegtab/src/main/java/org/kegbot/app/PourInProgressActivity.java
@@ -38,6 +38,7 @@ import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -467,6 +468,13 @@ public class PourInProgressActivity extends CoreActivity {
     mHandler.removeCallbacks(REFRESH_FLOWS_RUNNABLE);
     mCore.getBus().unregister(this);
     super.onPause();
+
+    if (mConfig.wakeDuringPour()) {
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN |
+                           WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
+                           WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                           WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
+    }
   }
 
   @Override

--- a/kegtab/src/main/java/org/kegbot/app/config/AppConfiguration.java
+++ b/kegtab/src/main/java/org/kegbot/app/config/AppConfiguration.java
@@ -296,6 +296,10 @@ public class AppConfiguration {
     return getBoolean(ConfigKey.KEEP_SCREEN_ON);
   }
 
+  public boolean wakeDuringPour() {
+    return getBoolean(ConfigKey.WAKE_DURING_POUR);
+  }
+
   public boolean isLocalBackend() {
     return getBoolean(ConfigKey.LOCAL_BACKEND);
   }

--- a/kegtab/src/main/java/org/kegbot/app/config/ConfigKey.java
+++ b/kegtab/src/main/java/org/kegbot/app/config/ConfigKey.java
@@ -67,6 +67,7 @@ enum ConfigKey {
 
   STAY_AWAKE(TRUE),
   KEEP_SCREEN_ON(TRUE),
+  WAKE_DURING_POUR(FALSE),
 
   EMAIL_ADDRESS(""),
 

--- a/kegtab/src/main/res/xml/settings_kegerator.xml
+++ b/kegtab/src/main/res/xml/settings_kegerator.xml
@@ -75,6 +75,13 @@
             android:summaryOn="The screen will stay on"
             android:title="Keep Screen On">
         </CheckBoxPreference>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="config:WAKE_DURING_POUR"
+            android:summaryOff="The screen will stay off when a pour starts"
+            android:summaryOn="The screen will turn on when a pour starts"
+            android:title="Wake During Pour">
+        </CheckBoxPreference>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This adds a configuration option in the Advanced Section of the Kegerator Settings for turning the screen on when a pour is initiated.  The way we have our Kegbot app set up is to turn the screen on in attract mode from 12pm-12am, and turn the screen off from 12am-12pm (via Tasker etc.).  This allows initiating a properly claiming a pour even when the screen is off (CPU wake lock).