### PR TITLE
Fix auto-photo on 2nd tap

### DIFF
--- a/kegtab/src/main/java/org/kegbot/app/PourInProgressActivity.java
+++ b/kegtab/src/main/java/org/kegbot/app/PourInProgressActivity.java
@@ -343,6 +343,17 @@ public class PourInProgressActivity extends CoreActivity {
       }
     });
 
+    /* Build mTapList so we can find the active Tap before starting the camera */
+    if (mTapList.size() == 0) {
+      synchronized (mTapsLock) {
+        for (final KegTap tap : mCore.getTapManager().getVisibleTaps()) {
+          mTapList.add(tap);
+        }
+        mPouringTapAdapter.notifyDataSetChanged();
+      }
+    }
+    scrollToMostActiveTap();
+
     mShowCamera = true;
     mCameraFragment = (CameraFragment) getFragmentManager().findFragmentById(R.id.camera);
     if (!mConfig.getUseCamera() || !mConfig.getTakePhotosDuringPour()) {
@@ -429,11 +440,14 @@ public class PourInProgressActivity extends CoreActivity {
   @Override
   protected void onStart() {
     super.onStart();
-    synchronized (mTapsLock) {
-      for (final KegTap tap : mCore.getTapManager().getVisibleTaps()) {
-        mTapList.add(tap);
+    Log.d(TAG, "onStart");
+    if (mTapList.size() == 0) {
+      synchronized (mTapsLock) {
+        for (final KegTap tap : mCore.getTapManager().getVisibleTaps()) {
+          mTapList.add(tap);
+        }
+        mPouringTapAdapter.notifyDataSetChanged();
       }
-      mPouringTapAdapter.notifyDataSetChanged();
     }
   }
 


### PR DESCRIPTION
In order for the photo taking to auto-start on a second tap, we must scrollToMostActiveTap before starting up the camera fragment. And we can't scroll before the mTapList is populated. Thus we need to populate mTapList during onCreate(), which happens before onStart().

Fixes #100 