### PR TITLE
Add support for CH340 devices (cheap arduino nano)

### DIFF
--- a/kegtab/src/main/res/xml/device_filter.xml
+++ b/kegtab/src/main/res/xml/device_filter.xml
@@ -23,6 +23,11 @@
         vendor-id="1027"
         product-id="24577"/>
 
+    <!-- 0x0403 / 0x6015: FTDI FT231X -->
+    <usb-device
+        vendor-id="1027"
+        product-id="24597"/>
+
     <!-- 0x2341 / Arduino -->
     <usb-device vendor-id="9025"/>
 
@@ -35,5 +40,18 @@
         vendor-id="1003"
         product-id="1078"/>
 
-</resources>
+    <!-- 0x10C4 / 0xEA60: CP210x UART Bridge -->
+    <usb-device
+        vendor-id="4292"
+        product-id="60000"/>
 
+    <!-- 0x067B / 0x2303: Prolific PL2303 -->
+    <usb-device
+        vendor-id="1659"
+        product-id="8963"/>
+
+    <!-- 0x1a86 / 0x7523: Qinheng CH340 -->
+    <usb-device
+        vendor-id="6790"
+        product-id="29987"/>
+</resources>


### PR DESCRIPTION
Update device filter to support CH340 serial devices commonly used on Knock-off Arduino boards.