### PR TITLE
Fix crash when tapping local backend radio button in setup

### DIFF
--- a/kegtab/src/main/java/org/kegbot/app/setup/SetupSelectBackendFragment.java
+++ b/kegtab/src/main/java/org/kegbot/app/setup/SetupSelectBackendFragment.java
@@ -39,9 +39,7 @@ import butterknife.ButterKnife;
  */
 public class SetupSelectBackendFragment extends SetupFragment {
 
-  private View mView;
-
-  private final DialogFragment mDialogFragment = new DialogFragment() {
+  public static class LocalBackendWarningDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
       AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -51,7 +49,9 @@ public class SetupSelectBackendFragment extends SetupFragment {
       builder.setCancelable(false);
       return builder.create();
     }
-  };
+  }
+
+  private View mView;
 
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -69,7 +69,7 @@ public class SetupSelectBackendFragment extends SetupFragment {
     button.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        mDialogFragment.show(getFragmentManager(), null);
+        new LocalBackendWarningDialog().show(getFragmentManager(), null);
       }
     });
 


### PR DESCRIPTION
## Summary

- Fixes a crash reported by @patfreeman when tapping the local backend radio button during setup
- `DialogFragment` subclasses must be `public static` so Android can recreate them from saved instance state; the anonymous inner class violated this requirement
- Extracted the anonymous class to a named `public static` inner class `LocalBackendWarningDialog`

## Test plan

- [ ] Open setup flow and tap the "Local" backend radio button — confirm the warning dialog appears without crashing
- [ ] Rotate the screen while the dialog is showing — confirm no crash on recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)